### PR TITLE
Pronouns input complete

### DIFF
--- a/reactdev/src/App.css
+++ b/reactdev/src/App.css
@@ -96,7 +96,7 @@ footer {
 }
 
 .bg-leaves {
-  background-image: url("../public/bg-leaves.webp");
+  background-image: url("/bg-leaves.webp");
   background-attachment: fixed;
   background-position: center;
   /* background-size: cover; */

--- a/reactdev/src/components/consent-form-components/clientInfo.jsx
+++ b/reactdev/src/components/consent-form-components/clientInfo.jsx
@@ -4,6 +4,7 @@ import FullNameInput from "../../input-components/FullNameInput";
 import EmailInput from "../../input-components/EmailInput";
 import AgeInput from "../../input-components/AgeInput";
 import PhoneNumberInput from "../../input-components/PhoneNumberInput";
+import PronounsInput from '../../input-components/PronounsInput';
 
 export default function ClientInfo({ props }) {
     return (
@@ -13,7 +14,8 @@ export default function ClientInfo({ props }) {
             <EmailInput props={props} inputId={"email"} />
             <AgeInput props={props} inputId={"age"} />
             <PhoneNumberInput props={props} inputId={"phone_number"} />
-            <div className="mb-3">
+            <PronounsInput props={props} inputId={"preferred_pronouns"} />
+            {/* <div className="mb-3">
                 <label htmlFor="preferred_pronouns" className="form-label mb-1">Preferred pronouns:<span className='text-danger'>*</span></label>
                 <select {...props.register("preferred_pronouns", {required: true})}
                     className={`form-select w-50 ${props.errors.preferred_pronouns ? "border-danger": ""}`}
@@ -26,8 +28,8 @@ export default function ClientInfo({ props }) {
                     <option value="other">other</option>
                 </select>
                 {props.errors.preferred_pronouns && <span className="text-danger">Please select your preferred pronouns.</span>}
-            </div>
-            <div className="mb-3">
+            </div> */}
+            <div className="mb-3 me-4">
                 <label htmlFor='birth_date' className="mb-1">Date of birth:<span className='text-danger'>*</span></label>
                 <input {...props.register("birth_date", { required: true })}
                     className={`form-control w-50 ${props.errors.birth_date ? "border-danger": ""}`}

--- a/reactdev/src/input-components/EmailInput.jsx
+++ b/reactdev/src/input-components/EmailInput.jsx
@@ -1,6 +1,6 @@
 export default function EmailInput({ props, inputId }) {
     return (
-        <div className="mb-3 form-floating">
+        <div className="mb-3 me-4 form-floating">
             <input {...props.register(inputId, {required: true})}
                 className={`form-control w-50 ${props.errors[inputId] ? "border-danger": ""}`}
                 onBlur={(e) => props.handleInputChange(e)}

--- a/reactdev/src/input-components/PronounsInput.jsx
+++ b/reactdev/src/input-components/PronounsInput.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react"
+
+export default function PronounsInput({ props, inputId }) {
+    const [other, setOther] = useState(false)
+
+    return (
+        <div className="mb-3 me-4">
+            <label htmlFor={inputId} className="form-label mb-1">
+                Preferred pronouns:<span className='text-danger'>*</span>
+            </label>
+            <select {...props.register(inputId, {required: true})}
+                className={`form-select w-50 ${props.errors[inputId] ? "border-danger": ""}`}
+                onChange={(e) => {
+                    props.handleInputChange(e)
+                    setOther(e.target.value === "other")
+                }}
+                id={inputId}>
+                <option value="">--Select your pronouns--</option>
+                <option value="he/him">he/him</option>
+                <option value="she/her">she/her</option>
+                <option value="they/them">they/them</option>
+                <option value="other">other</option>
+            </select>
+            {other && (
+                <div className="form-floating mt-3">
+                    <input {...props.register("custom_pronouns", {required: true})}
+                        type="text" className="form-control w-50"
+                        id="custom_pronouns" placeholder=""/>
+                    <label htmlFor="custom_pronouns">Please provide your pronouns</label>
+                </div>
+            )}
+            {props.errors["custom_pronouns"] && <span className="text-danger">Please provide your preferred pronouns.</span>}
+            {props.errors[inputId] && (
+                <span className="text-danger">Please select your preferred pronouns.</span>
+            )}
+        </div>
+    )
+}

--- a/reactdev/src/routes/consent.jsx
+++ b/reactdev/src/routes/consent.jsx
@@ -63,6 +63,9 @@ export default function ConsentForm() {
         for (let [key, value] of Object.entries(signatureTime)) {
             formData.append(key, value)
         }
+        if (formData["custom_pronouns"]) {
+            formData["preferred_pronouns"] = formData["custom_pronouns"]
+        }
 
         componentDisplay("completedForm", "submittedLoading")
 


### PR DESCRIPTION
# Description:

Added the pronouns input along with a new input "custom_pronouns" that only appears if you have selected "other". 

## Notes:

"custom_pronouns" is currently hard set. I have set it up so that the onSubmit function makes "preferred_pronouns" take "custom_pronouns". This is not modular and is bad practice. I could set something up that checks on the backend to see if the "custom_pronouns" is present, and if it is, then it will assign that to "preferred_pronouns" on the back end. This might end up being something that I need to use mongoDB for, because I don't need to declare how all of the documents will be stored in that case.